### PR TITLE
chore: 0.1.0 first history and drop deprecated aliases

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,8 +14,8 @@ This file contains workflow and orientation notes for AI agents working on this 
 - `src/delay/`: temporal delay infrastructure
   - `ring_buffer.rs`: `SpikeDelayBuffer` — ring-buffer delay queue for tick-aligned spike delivery
 - `src/mesh.rs`: `SynapticMesh` — top-level orchestrator owning graph + delays, provides `propagate()` 
-- `src/router.rs`: `ChannelRouter` — generic multi-channel SNN router (configurable channel count); `AhlRouter` is a backward-compatible type alias
-- `src/sparse.rs`: `SparseSynapticMap` CSR format, `NeuronStateSnapshot`, `RoutingPolicy`; `TelemetrySnapshot` is a backward-compatible type alias
+- `src/router.rs`: `ChannelRouter` — generic multi-channel SNN router (configurable channel count)
+- `src/sparse.rs`: `SparseSynapticMap` CSR format, `NeuronStateSnapshot`, `RoutingPolicy`
 - `src/tests.rs`: test suite for router + sparse modules
 
 ## Entry Order
@@ -31,7 +31,7 @@ This file contains workflow and orientation notes for AI agents working on this 
 - **Determinism**: all generators use index-based pseudo-random hashing (golden-ratio fractional), no external RNG. Same inputs always produce the same topology.
 - **Dale's Law**: neuron polarity is per-neuron (all outgoing synapses share polarity). First `inh_fraction × N` neurons are inhibitory.
 - **Temporal Delays**: per-synapse axonal delays stored in CSR alongside weights. Ring-buffer delivers spikes at correct future tick.
-- **Backward Compatibility**: existing `AhlRouter`, `SparseSynapticMap`, `TelemetrySnapshot`, `RoutingPolicy` all preserved.
+- **Public API**: `ChannelRouter` + `RouterConfig` is the router surface. Deprecated aliases (`AhlRouter`, `AHL_NUM_CHANNELS`, `TelemetrySnapshot`, `quant_bonus`, `quant_error`) were removed in 0.1.0.
 
 ## Workflow Policy
 
@@ -41,7 +41,7 @@ This file contains workflow and orientation notes for AI agents working on this 
 
 ## Repository Context
 
-- **Repo**: `Limen-Neural/synapse-router`
+- **Repo**: `Limen-Neural/synaptic-mesh`
 - **Main branch**: `main`
 - **Language**: Rust (edition 2024)
 - **Key concepts**: SNN wiring, topology generation, axonal delays, CSR sparse maps, Dale's law

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,3 +68,6 @@ First versioned history. Nothing before this tag was published or tagged.
 - Resolved clippy warnings (`RangeInclusive::contains`, iterator idioms,
   derivable impls, redundant borrows).
 - Fixed `cargo fmt` formatting (module ordering, debug_assert wrapping).
+
+[Unreleased]: https://github.com/Limen-Neural/synaptic-mesh/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/Limen-Neural/synaptic-mesh/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,27 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
+## [0.1.0] - 2026-08-14
 
-- **License**: Switched from `GPL-3.0-or-later` to dual `MIT OR Apache-2.0`.
-  This aligns `synaptic-mesh` with the rest of the Limen-Neural SNN stack and
-  permits broader downstream use. Old `LICENSE` (GPL-3.0) removed; replaced by
-  `LICENSE-MIT` and `LICENSE-APACHE-2.0`. SPDX identifier
-  `MIT OR Apache-2.0` added to all source files.
-- **BREAKING** — `apply_dale_polarity` (`topology::wiring_rules`) now returns
-  `Result<Vec<Polarity>, MeshError>` instead of `Vec<Polarity>`. Out-of-range
-  `inhibitory_fraction` values (< 0 or > 1) are now rejected with
-  `MeshError::InvalidConfig` instead of being silently clamped. All internal
-  callers updated; downstream crates must handle the new `Result` wrapper.
+First versioned history. Nothing before this tag was published or tagged.
 
 ### Added
 
+- Neuromodulatory adaptation in `ChannelRouter` — `NeuromodState` (cortisol,
+  dopamine, serotonin), `route_modulated()`, `apply_plasticity()`, per-channel
+  fatigue, use-it-or-lose-it plasticity.
+- Generic `ChannelRouter` with configurable channel count.
+- CSR sparse synaptic maps, topology generators (small-world, scale-free,
+  random, layered), temporal delay ring-buffer, Dale's law wiring.
 - **CI**: GitHub Actions workflow (`.github/workflows/ci.yml`) running
   `cargo fmt --check`, `cargo clippy -D warnings`, `cargo build`, and
   `cargo test` on every push/PR to `main`.
 - `inhibitory_fraction` range validation to all topology generators
   (`generate_random`, `generate_small_world`, `generate_scale_free`,
   `generate_layered`) — rejects values outside `[0, 1]`.
+
+### Changed
+
+- **License**: Dual `MIT OR Apache-2.0`. SPDX identifier added to all source
+  files.
+- `apply_dale_polarity` (`topology::wiring_rules`) returns
+  `Result<Vec<Polarity>, MeshError>` instead of `Vec<Polarity>`. Out-of-range
+  `inhibitory_fraction` values (< 0 or > 1) are rejected with
+  `MeshError::InvalidConfig`.
+
+### Removed
+
+- **`AhlRouter`** — use `ChannelRouter` with `RouterConfig::default()`.
+- **`AHL_NUM_CHANNELS`** — default channel count is `RouterConfig::default().channel_count` (3).
+- **`TelemetrySnapshot`** — use `NeuronStateSnapshot`.
+- **`NeuronStateSnapshot::quant_bonus`** — use `NeuronStateSnapshot::error_bonus`.
+- **`NeuronStateSnapshot::quant_error`** — use the `error` field.
+  The serde `alias = "quant_error"` on `error` is kept so older snapshots
+  still deserialize.
 
 ### Fixed
 
@@ -49,17 +65,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Internal
 
-- Resolved ~40 clippy warnings (`RangeInclusive::contains`, iterator idioms,
+- Resolved clippy warnings (`RangeInclusive::contains`, iterator idioms,
   derivable impls, redundant borrows).
 - Fixed `cargo fmt` formatting (module ordering, debug_assert wrapping).
-
-## [0.2.0] - 2026-05-28
-
-### Features Added
-
-- Neuromodulatory adaptation in `ChannelRouter` — `NeuromodState` (cortisol,
-  dopamine, serotonin), `route_modulated()`, `apply_plasticity()`, per-channel
-  fatigue, use-it-or-lose-it plasticity (PR #8).
-- Generic `ChannelRouter` replacing domain-specific `AhlRouter` (PR #7).
-- CSR sparse synaptic maps, topology generators (small-world, scale-free,
-  random, layered), temporal delay ring-buffer, Dale's law wiring.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "synaptic-mesh"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "synaptic-mesh"
+version = "0.1.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "An SNN based mesh for managing the wiring, topology, and temporal delays between neurons."

--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@
 <p align="center">SNN wiring, topology generation, and temporal delay infrastructure</p>
 
 <p align="center">
- <img src="https://img.shields.io/crates/v/synaptic-mesh" alt="crates.io"></a>
-  <a href="https://docs.rs/synaptic-mesh"><img src="https://docs.rs/synaptic-mesh/badge.svg" alt="docs.rs"></a>
+  <img src="https://img.shields.io/badge/version-0.1.0-informational" alt="0.1.0 (not yet on crates.io)">
   <img src="https://img.shields.io/badge/license-MIT%2FApache--2.0-blue" alt="MIT OR Apache-2.0">
 </p>
 
@@ -25,9 +24,13 @@
 
 ## Installation
 
+Not yet on crates.io. First publish is planned as **0.2.0**. Until then, depend on git:
+
 ```toml
-synaptic-mesh = "0.2"
+synaptic-mesh = { git = "https://github.com/Limen-Neural/synaptic-mesh" }
 ```
+
+After the `v0.1.0` tag exists you can pin it with `tag = "v0.1.0"`.
 
 ## Quick Start: Building a Mesh
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 ## Installation
 
-Not yet on crates.io. First publish is planned as **0.2.0**. Until then, depend on git:
+Not yet on crates.io. Until a crates.io release is available, depend on git:
 
 ```toml
 synaptic-mesh = { git = "https://github.com/Limen-Neural/synaptic-mesh" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,16 +120,10 @@ pub use types::{
 // Generic router exports (NeuromodNeuron is a router-internal NIF primitive; see "Crate boundary" above)
 pub use router::{ChannelRouter, NeuromodNeuron, NeuromodState, RouterConfig, RoutingDecision};
 
-// Backward-compatible router exports (deprecated)
-pub use router::{AHL_NUM_CHANNELS, AhlRouter};
-
 // Sparse map exports
 pub use sparse::{
     NeuronStateSnapshot, RoutingPolicy, SparseSynapticMap, SparseSynapticMapBuilder, Synapse,
 };
-
-// Backward-compatible sparse exports (deprecated)
-pub use sparse::TelemetrySnapshot;
 
 #[cfg(test)]
 mod tests;

--- a/src/router.rs
+++ b/src/router.rs
@@ -11,9 +11,6 @@
 
 use serde::{Deserialize, Serialize};
 
-/// Number of input channels for the default 3-channel router (backward compatible).
-pub const AHL_NUM_CHANNELS: usize = 3;
-
 /// Integration timesteps per routing decision (more → more stable).
 const ROUTING_TIMESTEPS: usize = 16;
 
@@ -267,11 +264,6 @@ pub struct ChannelRouter {
     #[serde(default)]
     baseline_weights: Vec<Vec<f32>>,
 }
-
-/// Backward-compatible alias for the default 3-channel router.
-///
-/// Deprecated: use [`ChannelRouter`] with [`RouterConfig::default()`] instead.
-pub type AhlRouter = ChannelRouter;
 
 impl Default for ChannelRouter {
     fn default() -> Self {

--- a/src/sparse.rs
+++ b/src/sparse.rs
@@ -286,11 +286,6 @@ pub struct NeuronStateSnapshot {
     pub step: u64,
 }
 
-/// Backward-compatible alias for [`NeuronStateSnapshot`].
-///
-/// Deprecated: use [`NeuronStateSnapshot`] instead.
-pub type TelemetrySnapshot = NeuronStateSnapshot;
-
 impl NeuronStateSnapshot {
     pub fn new(num_neurons: usize) -> Self {
         Self {
@@ -312,22 +307,6 @@ impl NeuronStateSnapshot {
     pub fn error_bonus(&self, neuron: usize, beta: f32) -> f32 {
         let err = self.error.get(neuron).copied().unwrap_or(0.0);
         beta * (1.0 - err.min(1.0))
-    }
-
-    /// Get a routing bonus for a neuron based on low quantization error.
-    ///
-    /// Deprecated: use [`NeuronStateSnapshot::error_bonus`] instead.
-    #[deprecated(since = "0.2.0", note = "use error_bonus instead")]
-    pub fn quant_bonus(&self, neuron: usize, beta: f32) -> f32 {
-        self.error_bonus(neuron, beta)
-    }
-
-    /// Get the estimated quantization error per neuron.
-    ///
-    /// Deprecated: use the [`NeuronStateSnapshot::error`] field directly.
-    #[deprecated(since = "0.2.0", note = "use error field instead")]
-    pub fn quant_error(&self) -> &[f32] {
-        &self.error
     }
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -157,13 +157,6 @@ fn custom_config_weights_applied() {
 }
 
 #[test]
-fn backward_compat_ahl_router_still_works() {
-    let mut router = crate::router::AhlRouter::new();
-    let d = router.route([1.0, 0.0, 0.0]).unwrap();
-    assert!(d.is_active(0));
-}
-
-#[test]
 fn route_accepts_array_by_value() {
     let mut router = ChannelRouter::new();
     let d = router.route([1.0, 0.0, 0.0]).unwrap();


### PR DESCRIPTION
## **User description**

Closes Limen-Neural/synaptic-mesh#12. Closes Limen-Neural/synaptic-mesh#32.

## Summary

First versioned history for the v0.1.0 tag (not a [crates.io](<http://crates.io>) publish). Public API no longer ships the old AhlRouter compatibility aliases.

## Limen-Neural/synaptic-mesh#32 — version / docs

* `Cargo.toml` / `Cargo.lock`: `version = "0.1.0"`
* `CHANGELOG.md`: single `[0.1.0] - 2026-08-14` (no claimed prior 0.2.0 ship)
* `README.md`: git install until 0.2.0; [crates.io](<http://crates.io>) 0.2 pin removed
* `AGENTS.md`: repo name is `Limen-Neural/synaptic-mesh`

## Limen-Neural/synaptic-mesh#12 — removed public aliases

<!-- linear:table-colwidths:400,400 -->
| Removed | Replacement |
| -- | -- |
| `AhlRouter` | `ChannelRouter` + `RouterConfig::default()` |
| `AHL_NUM_CHANNELS` | `RouterConfig::default().channel_count` (3) |
| `TelemetrySnapshot` | `NeuronStateSnapshot` |
| `quant_bonus` | `error_bonus` |
| `quant_error` | `error` field |

Kept `#[serde(alias = "quant_error")]` so older snapshots still deserialize.

## Verification

* `cargo fmt --check`
* `cargo test --locked` (65 unit + 2 doctests)
* `cargo clippy --all-features -- -D warnings`
* `REVIEW.md` API guards

## Milestone

v0.1.0 — API solidify

---

## **CodeAnt-AI Description**

Establish the 0.1.0 release and remove deprecated public API aliases

### What Changed

* The project is identified as version 0.1.0, with release notes covering the available routing, topology, delay, and validation features
* Deprecated router and telemetry names are no longer part of the public API; users must use `ChannelRouter`, `NeuronStateSnapshot`, and the current error terminology
* Older serialized snapshots using `quant_error` remain readable
* Installation guidance now points users to the repository until the first [crates.io](<http://crates.io>) release planned for 0.2.0

### Impact

`✅ Clear 0.1.0 release scope`<br>`✅ Fewer deprecated API names`<br>`✅ Existing quant_error snapshots still load`

<details><summary>💡 Usage Guide</summary>

### Checking Your Pull Request

Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI

Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:

```
@codeant-ai ask: Your question here
```

This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example

```
@codeant-ai ask: Can you suggest a safer alternative to storing this secret?
```

### Preserve Org Learnings with CodeAnt

You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:

```
@codeant-ai: Your feedback here
```

This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example

```
@codeant-ai: Do not flag unused imports.
```

### Retrigger review

Ask CodeAnt AI to review the PR again, by typing:

```
@codeant-ai: review
```

### Check Your Repository Health

To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](<https://app.codeant.ai>). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

---

## Summary by cubic

Solidifies the `synaptic-mesh` v0.1.0 API and removes deprecated aliases. Previously exported `AhlRouter`, `AHL_NUM_CHANNELS`, `TelemetrySnapshot`, `quant_bonus`, and `quant_error` are gone; `ChannelRouter` is the router surface, and older snapshots still deserialize via a serde alias on `error`.

* Required changes for downstream crates:
  * Replace `AhlRouter` with `ChannelRouter` and `RouterConfig::default()`.
  * Replace `AHL_NUM_CHANNELS` with `RouterConfig::default().channel_count` (3).
  * Rename `TelemetrySnapshot` to `NeuronStateSnapshot`.
  * Replace `quant_bonus` with `error_bonus`.
  * Use the `error` field instead of `quant_error` (serde alias retained; no data migration).
* Review notes:
  * Set `version = "0.1.0"` in `Cargo.toml` and `Cargo.lock`.
  * `CHANGELOG.md` collapsed to a single 0.1.0 entry and adds `[Unreleased]`/`[0.1.0]` links; dual-license is `MIT OR Apache-2.0`.
  * `README.md` uses git-based install and removes the unpublished 0.2.0 mention; adds a 0.1.0 badge.
  * Removed deprecated exports and their tests; `AGENTS.md` updates the repo name to `Limen-Neural/synaptic-mesh`.

Written for commit d9a24072f4db9bc824226e496589d2af0f607aef. Summary will update on new commits.

![Review in cubic](https://camo.githubusercontent.com/bd9efce2efa0a4d0a92a581dc73a4b2dc621085d3ac789eccf3330c974d2dae0/68747470733a2f2f7777772e63756269632e6465762f627574746f6e732f7265766965772d696e2d63756269632d6461726b2e737667)