### PR TITLE
chore: pin MSRV 1.97.1 and finish SynapticGraph serde tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,13 +20,51 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install Rust stable
-        # Not pinned to SHA: dtolnay/rust-toolchain uses rolling tags (stable, 1.96, etc.)
-        # rather than versioned releases. The `stable` ref always points to the latest
-        # action revision that supports the current stable Rust toolchain.
-        uses: dtolnay/rust-toolchain@stable
+      # Keep Cargo.toml rust-version, rust-toolchain.toml channel, and this
+      # job's toolchain: string identical (MSRV single source of truth — #35).
+      - name: Install Rust 1.97.1
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88
         with:
+          toolchain: 1.97.1
           components: clippy, rustfmt
+
+      - name: Verify MSRV pins agree
+        shell: bash
+        run: |
+          set -euo pipefail
+          strip_cr() { tr -d '\r'; }
+          cargo_rv=$(grep -m1 '^rust-version' Cargo.toml | sed -E 's/.*"([^"]+)".*/\1/' | strip_cr)
+          toolchain_ch=$(grep -m1 '^channel' rust-toolchain.toml | sed -E 's/.*"([^"]+)".*/\1/' | strip_cr)
+          ci_rv=$(awk '
+            BEGIN { want = 0; in_rt = 0; lines = 0 }
+            {
+              sub(/\r$/, "")
+            }
+            /^[[:space:]]*- name:[[:space:]]*Install Rust/ { want = 1; next }
+            want && /uses: dtolnay\/rust-toolchain@/ { in_rt = 1; next }
+            in_rt && /^[[:space:]]*toolchain:[[:space:]]*/ {
+              sub(/^[[:space:]]*toolchain:[[:space:]]*/, "")
+              sub(/[[:space:]]*$/, "")
+              print
+              exit 0
+            }
+            want {
+              lines++
+              if (lines > 20) exit 1
+              if (/^[[:space:]]*- name:/) exit 1
+            }
+          ' .github/workflows/ci.yml) || true
+          if [ -z "${ci_rv:-}" ]; then
+            echo "ERROR: Failed to extract toolchain: from Install Rust step in .github/workflows/ci.yml" >&2
+            exit 1
+          fi
+          echo "Cargo.toml rust-version=$cargo_rv"
+          echo "rust-toolchain.toml channel=$toolchain_ch"
+          echo "ci.yml pin=$ci_rv"
+          if [ "$cargo_rv" != "$toolchain_ch" ] || [ "$cargo_rv" != "$ci_rv" ]; then
+            echo "ERROR: MSRV pins disagree (must be identical)." >&2
+            exit 1
+          fi
 
       - name: Cache cargo registry
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ First versioned history. Nothing before this tag was published or tagged.
 - **CI**: GitHub Actions workflow (`.github/workflows/ci.yml`) running
   `cargo fmt --check`, `cargo clippy -D warnings`, `cargo build`, and
   `cargo test` on every push/PR to `main`.
+- MSRV pin **1.97.1** in `Cargo.toml` `rust-version`, `rust-toolchain.toml`,
+  and CI (`dtolnay/rust-toolchain` + pin-agreement check).
+- `PartialEq` on `SynapticGraph` and `SynapseDescriptor`, plus a JSON
+  serde round-trip test.
 - `inhibitory_fraction` range validation to all topology generators
   (`generate_random`, `generate_small_world`, `generate_scale_free`,
   `generate_layered`) — rejects values outside `[0, 1]`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,9 @@
 name = "synaptic-mesh"
 version = "0.1.0"
 edition = "2024"
+# Keep identical to rust-toolchain.toml `channel` and the CI workflow
+# `toolchain:` pin (see REVIEW.md "MSRV pin rule").
+rust-version = "1.97.1"
 license = "MIT OR Apache-2.0"
 description = "An SNN based mesh for managing the wiring, topology, and temporal delays between neurons."
 repository = "https://github.com/Limen-Neural/synaptic-mesh"

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -4,6 +4,21 @@ These commands are the **human quality bar** beyond GitHub Actions.
 Run them before claiming a PR is ready when the change touches `src/`,
 `Cargo.toml`, or public APIs.
 
+## MSRV pin rule
+
+`Cargo.toml` `rust-version`, `rust-toolchain.toml` `channel`, and the
+`toolchain:` string in `.github/workflows/ci.yml` must stay **identical**
+(currently **1.97.1**). CI fails if they drift (issue #35 / LIM-1042).
+
+To bump MSRV:
+
+1. Set the new version in Cargo.toml, rust-toolchain.toml, and ci.yml.
+2. Run the mandatory commands below on that toolchain
+   (`rustup run <ver> cargo test --locked`, etc.).
+3. Confirm GitHub Actions is green.
+
+Do not bump only one pin.
+
 ## When to run
 
 - Before every push that changes core mesh, topology, or neuromodulation code.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+# Keep identical to Cargo.toml `rust-version` and the CI workflow
+# `toolchain:` pin (see REVIEW.md "MSRV pin rule").
+channel = "1.97.1"
+components = ["clippy", "rustfmt"]

--- a/src/topology/graph.rs
+++ b/src/topology/graph.rs
@@ -6,6 +6,7 @@
 //! axonal delay and polarity information. This is the core "wiring diagram"
 //! that the `SynapticMesh` orchestrator uses for spike propagation.
 
+use serde::de::{Deserializer, Error as DeError};
 use serde::{Deserialize, Serialize};
 
 use crate::error::{MeshError, Result};
@@ -25,7 +26,7 @@ use crate::types::{DelayTicks, NeuronId, Polarity, SynapseDescriptor};
 /// delays:     [2, 5, 1, ...]            — axonal delay in ticks
 /// polarities: [Exc, Inh, Exc, ...]      — Dale's law polarity
 /// ```
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct SynapticGraph {
     /// Number of neurons in the graph.
     neuron_count: usize,
@@ -40,6 +41,68 @@ pub struct SynapticGraph {
     delays: Vec<DelayTicks>,
     /// Polarity per synapse.
     polarities: Vec<Polarity>,
+}
+
+impl<'de> Deserialize<'de> for SynapticGraph {
+    /// Deserializes and re-validates the CSR invariants that
+    /// [`SynapticGraph::from_descriptors`] enforces at construction time,
+    /// since a derived `Deserialize` would accept arbitrary field values
+    /// (mismatched `row_ptr` length, non-monotonic offsets, out-of-range
+    /// targets) that later panic in [`SynapticGraph::outgoing`] or
+    /// [`SynapticGraph::out_degree`].
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct RawSynapticGraph {
+            neuron_count: usize,
+            row_ptr: Vec<usize>,
+            targets: Vec<NeuronId>,
+            weights: Vec<f32>,
+            delays: Vec<DelayTicks>,
+            polarities: Vec<Polarity>,
+        }
+
+        let raw = RawSynapticGraph::deserialize(deserializer)?;
+
+        if raw.row_ptr.len() != raw.neuron_count + 1 {
+            return Err(DeError::custom(format!(
+                "row_ptr length {} does not match neuron_count + 1 ({})",
+                raw.row_ptr.len(),
+                raw.neuron_count + 1
+            )));
+        }
+        if raw.row_ptr.first().copied() != Some(0) {
+            return Err(DeError::custom("row_ptr must start at 0"));
+        }
+        if !raw.row_ptr.windows(2).all(|w| w[0] <= w[1]) {
+            return Err(DeError::custom("row_ptr must be non-decreasing"));
+        }
+
+        let nnz = *raw.row_ptr.last().expect("row_ptr is non-empty");
+        if raw.targets.len() != nnz
+            || raw.weights.len() != nnz
+            || raw.delays.len() != nnz
+            || raw.polarities.len() != nnz
+        {
+            return Err(DeError::custom(
+                "targets/weights/delays/polarities must each have length equal to row_ptr's final offset",
+            ));
+        }
+        if raw.targets.iter().any(|&t| t as usize >= raw.neuron_count) {
+            return Err(DeError::custom("target neuron id out of bounds"));
+        }
+
+        Ok(SynapticGraph {
+            neuron_count: raw.neuron_count,
+            row_ptr: raw.row_ptr,
+            targets: raw.targets,
+            weights: raw.weights,
+            delays: raw.delays,
+            polarities: raw.polarities,
+        })
+    }
 }
 
 impl SynapticGraph {
@@ -328,6 +391,30 @@ mod tests {
         ];
         let graph = SynapticGraph::from_descriptors(2, &descs).unwrap();
         assert_eq!(graph.max_delay(), 7);
+    }
+
+    #[test]
+    fn deserialize_rejects_row_ptr_length_mismatch() {
+        let json = r#"{"neuron_count":2,"row_ptr":[0,1],"targets":[],"weights":[],"delays":[],"polarities":[]}"#;
+        assert!(serde_json::from_str::<SynapticGraph>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_rejects_non_monotonic_row_ptr() {
+        let json = r#"{"neuron_count":2,"row_ptr":[0,3,1],"targets":[0,0,0],"weights":[0.1,0.1,0.1],"delays":[1,1,1],"polarities":["Excitatory","Excitatory","Excitatory"]}"#;
+        assert!(serde_json::from_str::<SynapticGraph>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_rejects_edge_array_length_mismatch() {
+        let json = r#"{"neuron_count":1,"row_ptr":[0,2],"targets":[0],"weights":[0.1,0.1],"delays":[1,1],"polarities":["Excitatory","Excitatory"]}"#;
+        assert!(serde_json::from_str::<SynapticGraph>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_rejects_out_of_range_target() {
+        let json = r#"{"neuron_count":1,"row_ptr":[0,1],"targets":[5],"weights":[0.1],"delays":[1],"polarities":["Excitatory"]}"#;
+        assert!(serde_json::from_str::<SynapticGraph>(json).is_err());
     }
 
     #[test]

--- a/src/topology/graph.rs
+++ b/src/topology/graph.rs
@@ -71,6 +71,7 @@ impl RawSynapticGraph {
             ],
         )?;
         validate_targets_in_bounds(&self.targets, self.neuron_count)?;
+        validate_weights_finite(&self.weights)?;
 
         Ok(SynapticGraph {
             neuron_count: self.neuron_count,
@@ -127,6 +128,16 @@ fn validate_targets_in_bounds(
 ) -> std::result::Result<(), String> {
     if targets.iter().any(|&t| t as usize >= neuron_count) {
         return Err("target neuron id out of bounds".to_string());
+    }
+    Ok(())
+}
+
+/// Checks that every weight is finite, so a non-JSON format (which, unlike
+/// JSON, can represent NaN/Inf) can't smuggle in a value that poisons
+/// current sums in [`crate::mesh::SynapticMesh::propagate`].
+fn validate_weights_finite(weights: &[f32]) -> std::result::Result<(), String> {
+    if weights.iter().any(|w| !w.is_finite()) {
+        return Err("synapse weight must be finite".to_string());
     }
     Ok(())
 }
@@ -446,6 +457,18 @@ mod tests {
     fn deserialize_rejects_edge_array_length_mismatch() {
         let json = r#"{"neuron_count":1,"row_ptr":[0,2],"targets":[0],"weights":[0.1,0.1],"delays":[1,1],"polarities":["Excitatory","Excitatory"]}"#;
         assert!(serde_json::from_str::<SynapticGraph>(json).is_err());
+    }
+
+    #[test]
+    fn validate_weights_finite_rejects_nan_and_infinite() {
+        // JSON has no literal for NaN/Infinity, so this exercises the
+        // validator directly rather than through a JSON round-trip; a
+        // non-JSON serde format (bincode, postcard, cbor) could otherwise
+        // smuggle these values into a deserialized graph.
+        assert!(validate_weights_finite(&[0.1, f32::NAN]).is_err());
+        assert!(validate_weights_finite(&[0.1, f32::INFINITY]).is_err());
+        assert!(validate_weights_finite(&[0.1, f32::NEG_INFINITY]).is_err());
+        assert!(validate_weights_finite(&[0.1, -0.4, 2.0]).is_ok());
     }
 
     #[test]

--- a/src/topology/graph.rs
+++ b/src/topology/graph.rs
@@ -25,7 +25,7 @@ use crate::types::{DelayTicks, NeuronId, Polarity, SynapseDescriptor};
 /// delays:     [2, 5, 1, ...]            — axonal delay in ticks
 /// polarities: [Exc, Inh, Exc, ...]      — Dale's law polarity
 /// ```
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct SynapticGraph {
     /// Number of neurons in the graph.
     neuron_count: usize,
@@ -273,6 +273,39 @@ mod tests {
             .find(|(_, _, _, p)| *p == Polarity::Inhibitory)
             .unwrap();
         assert!(inh_edge.1 < 0.0);
+    }
+
+    #[test]
+    fn synaptic_graph_json_roundtrip() {
+        let descs = vec![
+            SynapseDescriptor {
+                source: 0,
+                target: 1,
+                weight: 0.9,
+                delay: 3,
+                polarity: Polarity::Excitatory,
+            },
+            SynapseDescriptor {
+                source: 0,
+                target: 2,
+                weight: 0.15,
+                delay: 1,
+                polarity: Polarity::Inhibitory,
+            },
+            SynapseDescriptor {
+                source: 2,
+                target: 1,
+                weight: 0.4,
+                delay: 5,
+                polarity: Polarity::Excitatory,
+            },
+        ];
+        let graph = SynapticGraph::from_descriptors(3, &descs)
+            .expect("hand-written descriptors must build a graph");
+        let json = serde_json::to_string(&graph).expect("serialize SynapticGraph to JSON");
+        let restored: SynapticGraph =
+            serde_json::from_str(&json).expect("deserialize SynapticGraph from JSON");
+        assert_eq!(restored, graph);
     }
 
     #[test]

--- a/src/topology/graph.rs
+++ b/src/topology/graph.rs
@@ -43,65 +43,99 @@ pub struct SynapticGraph {
     polarities: Vec<Polarity>,
 }
 
+#[derive(Deserialize)]
+struct RawSynapticGraph {
+    neuron_count: usize,
+    row_ptr: Vec<usize>,
+    targets: Vec<NeuronId>,
+    weights: Vec<f32>,
+    delays: Vec<DelayTicks>,
+    polarities: Vec<Polarity>,
+}
+
+impl RawSynapticGraph {
+    /// Re-validates the CSR invariants that [`SynapticGraph::from_descriptors`]
+    /// enforces at construction time, since a derived `Deserialize` would
+    /// accept arbitrary field values (mismatched `row_ptr` length,
+    /// non-monotonic offsets, out-of-range targets) that later panic in
+    /// [`SynapticGraph::outgoing`] or [`SynapticGraph::out_degree`].
+    fn into_graph(self) -> std::result::Result<SynapticGraph, String> {
+        let nnz = validate_row_ptr(&self.row_ptr, self.neuron_count)?;
+        validate_edge_array_lengths(
+            nnz,
+            [
+                ("targets", self.targets.len()),
+                ("weights", self.weights.len()),
+                ("delays", self.delays.len()),
+                ("polarities", self.polarities.len()),
+            ],
+        )?;
+        validate_targets_in_bounds(&self.targets, self.neuron_count)?;
+
+        Ok(SynapticGraph {
+            neuron_count: self.neuron_count,
+            row_ptr: self.row_ptr,
+            targets: self.targets,
+            weights: self.weights,
+            delays: self.delays,
+            polarities: self.polarities,
+        })
+    }
+}
+
+/// Checks `row_ptr` has `neuron_count + 1` entries starting at 0 and
+/// non-decreasing, returning the total edge count (its final entry).
+fn validate_row_ptr(row_ptr: &[usize], neuron_count: usize) -> std::result::Result<usize, String> {
+    if row_ptr.len() != neuron_count + 1 {
+        return Err(format!(
+            "row_ptr length {} does not match neuron_count + 1 ({})",
+            row_ptr.len(),
+            neuron_count + 1
+        ));
+    }
+    if row_ptr.first().copied() != Some(0) {
+        return Err("row_ptr must start at 0".to_string());
+    }
+    if !row_ptr.windows(2).all(|w| w[0] <= w[1]) {
+        return Err("row_ptr must be non-decreasing".to_string());
+    }
+    Ok(*row_ptr.last().expect("row_ptr is non-empty"))
+}
+
+/// Checks that every named edge array has exactly `nnz` entries.
+fn validate_edge_array_lengths(
+    nnz: usize,
+    arrays: [(&str, usize); 4],
+) -> std::result::Result<(), String> {
+    for (name, len) in arrays {
+        if len != nnz {
+            return Err(format!(
+                "{name} length {len} does not match row_ptr's final offset {nnz}"
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Checks that every target neuron id is within `[0, neuron_count)`.
+fn validate_targets_in_bounds(
+    targets: &[NeuronId],
+    neuron_count: usize,
+) -> std::result::Result<(), String> {
+    if targets.iter().any(|&t| t as usize >= neuron_count) {
+        return Err("target neuron id out of bounds".to_string());
+    }
+    Ok(())
+}
+
 impl<'de> Deserialize<'de> for SynapticGraph {
-    /// Deserializes and re-validates the CSR invariants that
-    /// [`SynapticGraph::from_descriptors`] enforces at construction time,
-    /// since a derived `Deserialize` would accept arbitrary field values
-    /// (mismatched `row_ptr` length, non-monotonic offsets, out-of-range
-    /// targets) that later panic in [`SynapticGraph::outgoing`] or
-    /// [`SynapticGraph::out_degree`].
     fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
-        #[derive(Deserialize)]
-        struct RawSynapticGraph {
-            neuron_count: usize,
-            row_ptr: Vec<usize>,
-            targets: Vec<NeuronId>,
-            weights: Vec<f32>,
-            delays: Vec<DelayTicks>,
-            polarities: Vec<Polarity>,
-        }
-
-        let raw = RawSynapticGraph::deserialize(deserializer)?;
-
-        if raw.row_ptr.len() != raw.neuron_count + 1 {
-            return Err(DeError::custom(format!(
-                "row_ptr length {} does not match neuron_count + 1 ({})",
-                raw.row_ptr.len(),
-                raw.neuron_count + 1
-            )));
-        }
-        if raw.row_ptr.first().copied() != Some(0) {
-            return Err(DeError::custom("row_ptr must start at 0"));
-        }
-        if !raw.row_ptr.windows(2).all(|w| w[0] <= w[1]) {
-            return Err(DeError::custom("row_ptr must be non-decreasing"));
-        }
-
-        let nnz = *raw.row_ptr.last().expect("row_ptr is non-empty");
-        if raw.targets.len() != nnz
-            || raw.weights.len() != nnz
-            || raw.delays.len() != nnz
-            || raw.polarities.len() != nnz
-        {
-            return Err(DeError::custom(
-                "targets/weights/delays/polarities must each have length equal to row_ptr's final offset",
-            ));
-        }
-        if raw.targets.iter().any(|&t| t as usize >= raw.neuron_count) {
-            return Err(DeError::custom("target neuron id out of bounds"));
-        }
-
-        Ok(SynapticGraph {
-            neuron_count: raw.neuron_count,
-            row_ptr: raw.row_ptr,
-            targets: raw.targets,
-            weights: raw.weights,
-            delays: raw.delays,
-            polarities: raw.polarities,
-        })
+        RawSynapticGraph::deserialize(deserializer)?
+            .into_graph()
+            .map_err(DeError::custom)
     }
 }
 

--- a/src/topology/graph.rs
+++ b/src/topology/graph.rs
@@ -86,11 +86,14 @@ impl RawSynapticGraph {
 /// Checks `row_ptr` has `neuron_count + 1` entries starting at 0 and
 /// non-decreasing, returning the total edge count (its final entry).
 fn validate_row_ptr(row_ptr: &[usize], neuron_count: usize) -> std::result::Result<usize, String> {
-    if row_ptr.len() != neuron_count + 1 {
+    let expected_len = neuron_count
+        .checked_add(1)
+        .ok_or_else(|| format!("neuron_count {neuron_count} is too large"))?;
+    if row_ptr.len() != expected_len {
         return Err(format!(
             "row_ptr length {} does not match neuron_count + 1 ({})",
             row_ptr.len(),
-            neuron_count + 1
+            expected_len
         ));
     }
     if row_ptr.first().copied() != Some(0) {
@@ -442,6 +445,12 @@ mod tests {
     #[test]
     fn deserialize_rejects_edge_array_length_mismatch() {
         let json = r#"{"neuron_count":1,"row_ptr":[0,2],"targets":[0],"weights":[0.1,0.1],"delays":[1,1],"polarities":["Excitatory","Excitatory"]}"#;
+        assert!(serde_json::from_str::<SynapticGraph>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_rejects_usize_max_neuron_count_without_overflow_panic() {
+        let json = r#"{"neuron_count":18446744073709551615,"row_ptr":[0,1],"targets":[0],"weights":[0.1],"delays":[1],"polarities":["Excitatory"]}"#;
         assert!(serde_json::from_str::<SynapticGraph>(json).is_err());
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -47,7 +47,7 @@ impl Polarity {
 // ── Synapse descriptor ────────────────────────────────────────────────────────
 
 /// A fully-described synaptic connection with weight, delay, and polarity.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct SynapseDescriptor {
     /// Source neuron.
     pub source: NeuronId,

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,6 +5,7 @@
 //! Shared scalar types, measurement units, and configuration structs used
 //! across the topology, delay, and mesh modules.
 
+use serde::de::{Deserializer, Error as DeError};
 use serde::{Deserialize, Serialize};
 
 // ── Scalar aliases ────────────────────────────────────────────────────────────
@@ -54,6 +55,7 @@ pub struct SynapseDescriptor {
     /// Target neuron.
     pub target: NeuronId,
     /// Absolute synaptic weight (always ≥ 0; sign comes from polarity).
+    #[serde(deserialize_with = "deserialize_nonnegative_weight")]
     pub weight: f32,
     /// Axonal propagation delay in ticks.
     pub delay: DelayTicks,
@@ -66,6 +68,22 @@ impl SynapseDescriptor {
     pub fn effective_weight(&self) -> f32 {
         self.weight * self.polarity.sign()
     }
+}
+
+/// Rejects negative or non-finite weights so deserialized descriptors keep
+/// the documented `weight >= 0` invariant that [`SynapseDescriptor::effective_weight`]
+/// relies on to apply polarity correctly.
+fn deserialize_nonnegative_weight<'de, D>(deserializer: D) -> std::result::Result<f32, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let weight = f32::deserialize(deserializer)?;
+    if !weight.is_finite() || weight < 0.0 {
+        return Err(DeError::custom(format!(
+            "synapse weight must be finite and non-negative, got {weight}"
+        )));
+    }
+    Ok(weight)
 }
 
 // ── Topology parameters ──────────────────────────────────────────────────────
@@ -150,5 +168,24 @@ pub enum DelayModel {
 impl Default for DelayModel {
     fn default() -> Self {
         Self::Fixed { delay: 1 }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserialize_rejects_negative_weight() {
+        let json = r#"{"source":0,"target":1,"weight":-0.5,"delay":1,"polarity":"Excitatory"}"#;
+        assert!(serde_json::from_str::<SynapseDescriptor>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_accepts_valid_weight() {
+        let json = r#"{"source":0,"target":1,"weight":0.5,"delay":1,"polarity":"Inhibitory"}"#;
+        let desc: SynapseDescriptor = serde_json::from_str(json).unwrap();
+        assert_eq!(desc.weight, 0.5);
+        assert!((desc.effective_weight() + 0.5).abs() < 1e-6);
     }
 }


### PR DESCRIPTION
## **User description**

Closes Limen-Neural/synaptic-mesh#35. Closes Limen-Neural/synaptic-mesh#18.

Completes the remaining **v0.1.0 — API solidify** code work. Do **not** tag `v0.1.0` until this is on `main` (Limen-Neural/synaptic-mesh#33).

## Limen-Neural/synaptic-mesh#35 — MSRV 1.97.1

Single pin, same as axon-encoder / neuromod:

* `Cargo.toml` `rust-version = "1.97.1"`
* `rust-toolchain.toml` `channel = "1.97.1"` (clippy + rustfmt)
* CI installs `dtolnay/rust-toolchain` with `toolchain: 1.97.1` (pinned SHA)
* CI step **Verify MSRV pins agree** (Cargo.toml / rust-toolchain.toml / ci.yml)
* `REVIEW.md` MSRV pin rule

Local `rustup show` reports **1.97.1** via `rust-toolchain.toml`.

## Limen-Neural/synaptic-mesh#18 — serde finish

* `PartialEq` on `SynapticGraph` and `SynapseDescriptor` (no `Eq`; `f32`)
* `synaptic_graph_json_roundtrip` in `src/topology/graph.rs`

## Verification

* `cargo fmt --check`
* `cargo test --locked` (66 unit + 2 doctests)
* `cargo clippy --all-features -- -D warnings`

Grok Build: Grok 4.6 (medium)

## Summary by cubic

Pins the MSRV to Rust 1.97.1 across Cargo, `rust-toolchain.toml`, and CI, and adds `PartialEq` plus a JSON round-trip serde test for `SynapticGraph` and `SynapseDescriptor`. Previously CI used a rolling stable; now CI enforces pin agreement to ensure reproducible builds and validated serialization.

* Migration
  * Use Rust 1.97.1 locally; `rust-toolchain.toml` selects it and `clippy`/`rustfmt` run on that toolchain.
  * To change MSRV, update Cargo.toml `rust-version`, `rust-toolchain.toml` `channel`, and the CI `toolchain:` for `dtolnay/rust-toolchain` together; CI fails if they differ.

Written for commit 1df4a35fa8f646b78838f6a2e5821f1fc8678f39. Summary will update on new commits.

![Review in cubic](https://camo.githubusercontent.com/bd9efce2efa0a4d0a92a581dc73a4b2dc621085d3ac789eccf3330c974d2dae0/68747470733a2f2f7777772e63756269632e6465762f627574746f6e732f7265766965772d696e2d63756269632d6461726b2e737667)

> \[!NOTE\] **Low Risk**  <br>Toolchain and documentation pins plus stricter deserialization on topology types; no runtime mesh/router logic changes and invalid JSON now fails at parse time instead of later panics.
>
> **Overview**\*\*  <br>\*\***MSRV 1.97.1** replaces rolling `stable` in CI with a pinned `dtolnay/rust-toolchain` action, adds `rust-version` in `Cargo.toml` and `rust-toolchain.toml`, and runs a **Verify MSRV pins agree** step so `Cargo.toml`, `rust-toolchain.toml`, and `ci.yml` must match. `REVIEW.md` documents the single-source-of-truth rule.
>
> **Serde / API solidify:** `PartialEq` is added on `SynapticGraph` and `SynapseDescriptor`. `SynapticGraph` gets a **custom** `Deserialize` that re-checks CSR invariants (row_ptr shape, monotonicity, edge array lengths, target bounds) instead of accepting arbitrary JSON that could panic later. `SynapseDescriptor` rejects non-finite or negative weights on deserialize.
>
> Tests cover a JSON round-trip for `SynapticGraph` and failure cases for invalid graph JSON and bad descriptor weights.
>
> Reviewed by [Cursor Bugbot](<https://cursor.com/bugbot>) for commit 86f7bce5b2d56e6343c5322936af109f9a69109f. Configure [here](<https://www.cursor.com/dashboard/bugbot>).

---

## **CodeAnt-AI Description**

Validate deserialized synaptic graphs and weights before use

### What Changed

* Rejects malformed graph data with invalid row structure, mismatched edge data, or targets outside the neuron range
* Rejects negative, infinite, and non-numeric synapse weights during deserialization
* Confirms valid graphs survive JSON serialization and restoration without changes
* Standardizes local development and CI on Rust 1.97.1, with CI detecting mismatched version settings

### Impact

`✅ Fewer panics from malformed graph data`  <br>`✅ Prevented polarity errors from invalid synapse weights`  <br>`✅ Consistent builds on Rust 1.97.1`

<details><summary>💡 Usage Guide</summary>

### Checking Your Pull Request

Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI

Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:

```
@codeant-ai ask: Your question here
```

This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example

```
@codeant-ai ask: Can you suggest a safer alternative to storing this secret?
```

### Preserve Org Learnings with CodeAnt

You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:

```
@codeant-ai: Your feedback here
```

This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example

```
@codeant-ai: Do not flag unused imports.
```

### Retrigger review

Ask CodeAnt AI to review the PR again, by typing:

```
@codeant-ai: review
```

### Check Your Repository Health

To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](<https://app.codeant.ai>). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>