### PR TITLE
feat: add cargo profiles for dev, test, release, and bench

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,29 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 [workspace]
+
+# Fast iteration: no optimization, full debug info, incremental compiles.
+[profile.dev]
+opt-level = 0
+debug = true
+incremental = true
+
+# Slightly optimized so the growing unit/property-test suite (GH#21) runs
+# faster, while keeping compile times close to `dev`.
+[profile.test]
+inherits = "dev"
+opt-level = 1
+
+# Tuned for the crates.io publish (GH#37): maximize runtime performance and
+# minimize binary size, with thin LTO to keep build times reasonable.
+[profile.release]
+opt-level = 3
+lto = "thin"
+codegen-units = 1
+strip = true
+
+# Mirrors `release` so criterion benchmarks (GH#17) reflect real release
+# performance; keep debug symbols so profilers can still symbolize.
+[profile.bench]
+inherits = "release"
+debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,9 @@ codegen-units = 1
 strip = true
 
 # Mirrors `release` so criterion benchmarks (GH#17) reflect real release
-# performance; keep debug symbols so profilers can still symbolize.
+# performance; keep debug symbols so profilers can still symbolize (override
+# `release`'s strip, which would otherwise discard them).
 [profile.bench]
 inherits = "release"
 debug = true
+strip = false


### PR DESCRIPTION
## **User description**
## Summary

- Root `Cargo.toml` had no `[profile.*]` sections, so every profile silently fell back to Cargo defaults. This adds all four explicitly, each with a short rationale comment:
  - `[profile.dev]` — fast iteration: `opt-level = 0`, full debug info, incremental.
  - `[profile.test]` — inherits `dev`, `opt-level = 1` so the growing unit/property-test suite (GH#21) runs a bit faster without hurting compile times much.
  - `[profile.release]` — tuned for the eventual crates.io publish (GH#37): `opt-level = 3`, thin LTO, `codegen-units = 1`, `strip = true`.
  - `[profile.bench]` — inherits `release` so criterion benchmarks (GH#17) reflect real release performance, keeps `debug = true` for profiler symbolization.

Closes #40.

## Test plan

- [x] `cargo build`
- [x] `cargo build --release`
- [x] `cargo test` (74 passed, 2 doctests passed)
- [x] `cargo bench --no-run`
- [x] `cargo fmt --check`
- [x] `cargo test --locked`
- [x] `cargo clippy --all-features -- -D warnings`

_Generated by [Claude Code](https://claude.ai/code/session_01AYrJQcN8Lw26wHz5FQ1aBa)_

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds explicit cargo profiles to the root `Cargo.toml`, which previously had none and silently fell back to Cargo defaults. `dev` focuses on fast iteration, `test` adds light optimization for quicker test runs, `release` targets runtime performance and smaller binaries, and `bench` mirrors `release` for realistic criterion results. Closes GH#40.

**Bench profile**
- Overrides the inherited `strip = true` with `strip = false` so debug symbols are actually retained for profiling.

<sup>Written for commit d3b8c0d68517428d4a10e250a73937ddb6dc71da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Limen-Neural/synaptic-mesh/pull/44?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Configure build profiles for faster development, optimized releases, and accurate profiling

### What Changed
- Development builds keep full debug information and support incremental compilation for quicker iteration
- Test builds use light optimization to speed up the test suite without significantly increasing build time
- Release builds prioritize runtime performance and smaller binaries
- Benchmark builds match release performance while retaining debug symbols for profiler output

### Impact
`✅ Faster test runs`
`✅ Smaller, faster release binaries`
`✅ Usable benchmark profiling symbols`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
