### PR TITLE
ci: exercise all four cargo profiles (dev/test/release/bench)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,9 @@ jobs:
       - name: Clippy (lint)
         run: cargo clippy --locked --all-targets --all-features -- -D warnings
 
-      - name: Build
+      # Exercises [profile.dev] (see #40/#41) — a misconfigured or reverted
+      # dev profile fails to compile here.
+      - name: Build (dev profile)
         run: cargo build --locked --all-features
 
       - name: Documentation
@@ -90,5 +92,16 @@ jobs:
         env:
           RUSTDOCFLAGS: "-D warnings"
 
-      - name: Test
+      # Exercises [profile.release] (see #40/#41) — catches a release profile
+      # that no longer compiles (e.g. an invalid lto/codegen-units setting).
+      - name: Build (release profile)
+        run: cargo build --locked --all-features --release
+
+      # Exercises [profile.test] (see #40/#41).
+      - name: Test (test profile)
         run: cargo test --locked --all-features
+
+      # Exercises [profile.bench] (see #40/#41). Compile-only: no benches are
+      # defined yet (#17), so this just confirms the profile itself is valid.
+      - name: Bench compile check (bench profile)
+        run: cargo bench --locked --all-features --no-run


### PR DESCRIPTION
## Summary

- CI already built with the default `dev` profile and ran `cargo test` under `test`, but never touched `release` or `bench`, so a profile regression there would only surface locally.
- Added two steps to `.github/workflows/ci.yml`:
  - **Build (release profile)** — `cargo build --locked --all-features --release`
  - **Bench compile check (bench profile)** — `cargo bench --locked --all-features --no-run` (compile-only since no `criterion` benches exist yet, tracked in #17)
- Relabeled the existing `Build`/`Test` steps to `Build (dev profile)` / `Test (test profile)` and added comments cross-referencing #40/#41, so each of the four profiles maps to a clearly named CI step.
- Per the exit criteria in #41, a broken/misconfigured profile now fails CI because the corresponding `cargo build`/`test`/`bench` command itself fails (invalid TOML, invalid profile keys, etc.), rather than only relying on hand-picked assertions of specific `opt-level`/`lto` values.

## Update: #40 has merged

#40's `[profile.*]` tables landed via #44 while this PR was open. `main` was merged into this branch, so these CI steps now exercise the real dev/test/release/bench profiles (verified locally: dev is unoptimized+debuginfo, test is opt-level 1, release is optimized with thin LTO, bench mirrors release with debug symbols retained) — not just Cargo's defaults.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --locked --all-targets --all-features -- -D warnings`
- [x] `cargo build --locked --all-features` (dev)
- [x] `cargo doc --locked --all-features --no-deps --document-private-items`
- [x] `cargo build --locked --all-features --release` (release)
- [x] `cargo test --locked --all-features` (test) — 74 tests + 2 doctests passed
- [x] `cargo bench --locked --all-features --no-run` (bench)

Closes #41.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XjzJTqBdSh289nqeYji6Z3