### PR TITLE
Add cargo-audit / cargo-deny CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,3 +92,16 @@ jobs:
 
       - name: Test
         run: cargo test --locked --all-features
+
+  cargo-deny:
+    name: Dependency audit (cargo-deny)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: cargo-deny (advisories, licenses, bans, sources)
+        uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,5 +103,8 @@ jobs:
         with:
           persist-credentials: false
 
+      # Keep in sync with the MSRV pin rule in REVIEW.md (issue #35).
       - name: cargo-deny (advisories, licenses, bans, sources)
         uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
+        with:
+          rust-version: "1.97.1"

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,46 @@
+# cargo-deny configuration (GH#42).
+#
+# Run locally with: cargo deny check
+# Docs: https://embarkstudios.github.io/cargo-deny/
+
+[graph]
+all-features = true
+
+[advisories]
+# Fail the build on any published RustSec advisory (vulnerability or
+# unmaintained-crate notice) affecting a dependency in the tree.
+unmaintained = "all"
+unsound = "all"
+yanked = "deny"
+ignore = []
+
+[licenses]
+confidence-threshold = 0.93
+# Kept compatible with this crate's dual MIT/Apache-2.0 licensing (see GH#11)
+# plus the small set of permissive licenses used by our current dependency
+# tree (e.g. unicode-ident's Unicode-3.0 grant).
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "Unicode-3.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Zlib",
+    "CC0-1.0",
+]
+exceptions = []
+
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"
+deny = []
+skip = []
+skip-tree = []
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []


### PR DESCRIPTION
## **User description**
Closes #42.

## Summary

- Added `deny.toml` configuring `cargo-deny` to check advisories (known vulnerabilities + yanked/unmaintained crates), license compliance, banned/duplicate dependencies, and dependency sources.
- License allowlist is kept compatible with this crate's dual `MIT OR Apache-2.0` licensing (#11), plus the small set of additional permissive licenses (`Unicode-3.0`, `BSD-2-Clause`, `BSD-3-Clause`, `ISC`, `Zlib`, `CC0-1.0`, `Apache-2.0 WITH LLVM-exception`) commonly needed by Rust dependency trees, so routine dependency additions don't immediately break CI.
- Wired a new `cargo-deny` job into `.github/workflows/ci.yml` (existing workflow from #10) using the pinned `EmbarkStudios/cargo-deny-action@v2.1.1`, running alongside the existing `validate` job on every push/PR to `main`.
- Pinned the job's Rust toolchain to the repo's MSRV (1.97.1, per REVIEW.md / #35) so it matches the `validate` job instead of defaulting to `stable`.

Went with `cargo-deny` over `cargo-audit` per the issue's suggestion, since it subsumes vulnerability advisory checking while also covering licenses, bans, and sources in one job.

## Test plan

- [x] Installed `cargo-deny` locally and ran `cargo deny check` against the current dependency tree: `advisories ok, bans ok, licenses ok, sources ok`.
- [x] Validated `.github/workflows/ci.yml` YAML syntax.
- [x] CI ran the new `cargo-deny` job on this PR — passed (along with `Build & Test`, `qodana`, `Codacy`, `qlty`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LCvPrmqBoodBBUPoPHXvcv

---
_Generated by [Claude Code](https://claude.ai/code/session_01LCvPrmqBoodBBUPoPHXvcv)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `cargo-deny` CI job that audits the dependency tree on every push/PR to `main`, closing #42.

- Checks known vulnerabilities, yanked/unmaintained crates, license compliance, banned/duplicate dependencies, and crate sources.
- License allowlist stays compatible with the crate's `MIT OR Apache-2.0` licensing (#11) plus common permissive licenses, so routine dependency additions don't break CI.
- Configures `cargo-deny` in a new `deny.toml`; CI uses the pinned `EmbarkStudios/cargo-deny-action@v2.1.1`.
- Pins the job's Rust toolchain to the repo's MSRV (1.97.1) so the audit runs on the same toolchain as the rest of CI.

<sup>Written for commit 02895b6ed8b447b3804e85d9bb33cc09f0ca730b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Limen-Neural/synaptic-mesh/pull/46?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture>``&lt;source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"&gt;&lt;source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"&gt;&lt;img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"&gt;``</picture></a>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
Add automated dependency safety checks to CI

### What Changed
- Every push and pull request now checks dependencies for known security advisories, yanked or unmaintained crates, and unsound packages
- CI rejects dependencies with unapproved licenses, wildcard versions, unknown registries, or unapproved Git sources
- Duplicate dependency versions are reported as warnings without blocking builds

### Impact
`✅ Earlier detection of vulnerable dependencies`
`✅ Fewer licensing and dependency-source compliance issues`
`✅ Safer releases before publishing`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
