### PR TITLE
docs: document cargo build profiles in REVIEW.md

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,9 +43,10 @@ lto = "thin"
 codegen-units = 1
 strip = true
 
-# Mirrors `release` so criterion benchmarks (GH#17) reflect real release
-# performance; keep debug symbols so profilers can still symbolize (override
-# `release`'s strip, which would otherwise discard them).
+# Mirrors `release` so that once benchmarks are added (GH#17, not yet
+# implemented), they reflect real release performance; keep debug symbols
+# so profilers can still symbolize (override `release`'s strip, which
+# would otherwise discard them).
 [profile.bench]
 inherits = "release"
 debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,9 @@ serde_json = "1.0"
 
 [workspace]
 
+# See REVIEW.md "Build profiles" for a table of when to use each profile
+# below and the command that invokes it.
+
 # Fast iteration: no optimization, full debug info, incremental compiles.
 [profile.dev]
 opt-level = 0

--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ synaptic-mesh = { git = "https://github.com/Limen-Neural/synaptic-mesh" }
 
 After the `v0.1.0` tag exists you can pin it with `tag = "v0.1.0"`.
 
+See [REVIEW.md](REVIEW.md#build-profiles) for which cargo build profile
+(`dev`, `test`, `release`, `bench`) to use and why.
+
 ## Quick Start: Building a Mesh
 
 ```rust

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -30,7 +30,7 @@ that matches what you're doing instead of reaching for a one-off
 | `dev`     | `cargo build` / `cargo run`  | `opt-level = 0`, full debug info, incremental compiles — fastest edit/compile loop. |
 | `test`    | `cargo test`                 | Inherits `dev` but bumps to `opt-level = 1` so the unit/property-test suite (GH#21) runs faster, while keeping compile times close to `dev`. |
 | `release` | `cargo build --release`      | `opt-level = 3`, thin LTO, single codegen unit, stripped — tuned for the crates.io publish (GH#37): best runtime performance and smallest binary. |
-| `bench`   | `cargo bench`                | Inherits `release` so that once benchmarks are added (issue #17, not yet implemented), they reflect real release performance, but keeps debug symbols (`strip = false`) so profilers can still symbolize. |
+| `bench`   | `cargo bench`                | Inherits `release` so that once benchmarks are added (GH#17, not yet implemented), they reflect real release performance, but keeps debug symbols (`strip = false`) so profilers can still symbolize. |
 
 The rationale above is kept in sync with the comments on each
 `[profile.*]` block in `Cargo.toml` — update both together if a profile

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -30,7 +30,7 @@ that matches what you're doing instead of reaching for a one-off
 | `dev`     | `cargo build` / `cargo run`  | `opt-level = 0`, full debug info, incremental compiles — fastest edit/compile loop. |
 | `test`    | `cargo test`                 | Inherits `dev` but bumps to `opt-level = 1` so the unit/property-test suite (GH#21) runs faster, while keeping compile times close to `dev`. |
 | `release` | `cargo build --release`      | `opt-level = 3`, thin LTO, single codegen unit, stripped — tuned for the crates.io publish (GH#37): best runtime performance and smallest binary. |
-| `bench`   | `cargo bench`                | Inherits `release` so criterion benchmarks (GH#17) reflect real release performance, but keeps debug symbols (`strip = false`) so profilers can still symbolize. |
+| `bench`   | `cargo bench`                | Inherits `release` so that once benchmarks are added (issue #17, not yet implemented), they reflect real release performance, but keeps debug symbols (`strip = false`) so profilers can still symbolize. |
 
 The rationale above is kept in sync with the comments on each
 `[profile.*]` block in `Cargo.toml` — update both together if a profile

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -19,6 +19,23 @@ To bump MSRV:
 
 Do not bump only one pin.
 
+## Build profiles
+
+`Cargo.toml` defines four `[profile.*]` sections (issue #40). Use the one
+that matches what you're doing instead of reaching for a one-off
+`cargo build` flag:
+
+| Profile   | Command                     | Why it's configured that way |
+|-----------|------------------------------|-------------------------------|
+| `dev`     | `cargo build` / `cargo run`  | `opt-level = 0`, full debug info, incremental compiles — fastest edit/compile loop. |
+| `test`    | `cargo test`                 | Inherits `dev` but bumps to `opt-level = 1` so the unit/property-test suite (GH#21) runs faster, while keeping compile times close to `dev`. |
+| `release` | `cargo build --release`      | `opt-level = 3`, thin LTO, single codegen unit, stripped — tuned for the crates.io publish (GH#37): best runtime performance and smallest binary. |
+| `bench`   | `cargo bench`                | Inherits `release` so criterion benchmarks (GH#17) reflect real release performance, but keeps debug symbols (`strip = false`) so profilers can still symbolize. |
+
+The rationale above is kept in sync with the comments on each
+`[profile.*]` block in `Cargo.toml` — update both together if a profile
+changes.
+
 ## When to run
 
 - Before every push that changes core mesh, topology, or neuromodulation code.


### PR DESCRIPTION
Closes #43.

## Summary

- Adds a "Build profiles" section to `REVIEW.md`, matching the existing "MSRV pin rule" style, with a table listing each cargo profile (`dev`, `test`, `release`, `bench`), the command that uses it, and a one-line rationale for its configuration.
- Cross-references the new section from the `[profile.*]` comments in `Cargo.toml`.
- Links to the section from `README.md`'s Installation area so contributors can find it without digging.

## Test plan

- [x] `cargo metadata` confirms `Cargo.toml` still parses after the added comment.
- [x] Reviewed rendered Markdown table/links for correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P7afRMxHFJqnjdVqFkunyD

---
_Generated by [Claude Code](https://claude.ai/code/session_01P7afRMxHFJqnjdVqFkunyD)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the four cargo build profiles (`dev`, `test`, `release`, `bench`) in REVIEW.md so contributors know which to use instead of reaching for one-off `cargo build` flags.

- The bench profile row clarifies that benchmarks aren't implemented yet, so it doesn't overclaim that they reflect release performance.
- Cross-links the section from `Cargo.toml` profile comments and `README.md`, and warns to keep the rationale in sync with the `[profile.*]` comments.

<sup>Written for commit f4c388b1503ce8b34dd267dbb6335f711f8bda80. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Limen-Neural/synaptic-mesh/pull/47?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

