### PR TITLE
chore: 0.2.0 release — build & test tooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-09-06
+
+Bridges v0.1.0 (API solidify) and v0.3.0 (first crates.io publish). Hardens
+the build/test/bench setup ahead of packaging for publish.
+
+### Added
+
+- **Cargo profiles**: explicit `[profile.dev]`, `[profile.test]`,
+  `[profile.release]`, and `[profile.bench]` in `Cargo.toml`, each tuned and
+  documented with a rationale comment (issue #40).
+- **CI**: workflow now builds under `release` and compiles under `bench`
+  in addition to the existing `dev` build and `test` run, so a broken or
+  reverted profile fails CI instead of only surfacing locally (issue #41).
+- **CI**: `cargo-deny` job checking advisories, license allowlist (dual
+  MIT/Apache-2.0), bans, and sources ahead of the crates.io publish
+  (issue #42).
+- **Docs**: "Build profiles" section in `REVIEW.md` listing each profile,
+  the command that uses it, and why it's configured that way, cross-linked
+  from `Cargo.toml` and `README.md` (issue #43).
+
+[0.2.0]: https://github.com/Limen-Neural/synaptic-mesh/compare/v0.1.0...v0.2.0
+
 ## [0.1.0] - 2026-08-14
 
 First versioned history. Nothing before this tag was published or tagged.
@@ -73,5 +95,5 @@ First versioned history. Nothing before this tag was published or tagged.
   derivable impls, redundant borrows).
 - Fixed `cargo fmt` formatting (module ordering, debug_assert wrapping).
 
-[Unreleased]: https://github.com/Limen-Neural/synaptic-mesh/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/Limen-Neural/synaptic-mesh/compare/v0.2.0...HEAD
 [0.1.0]: https://github.com/Limen-Neural/synaptic-mesh/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "synaptic-mesh"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "synaptic-mesh"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 # Keep identical to rust-toolchain.toml `channel` and the CI workflow
 # `toolchain:` pin (see REVIEW.md "MSRV pin rule").

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 <p align="center">SNN wiring, topology generation, and temporal delay infrastructure</p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.1.0-informational" alt="0.1.0 (not yet on crates.io)">
+  <img src="https://img.shields.io/badge/version-0.2.0-informational" alt="0.2.0 (not yet on crates.io)">
   <img src="https://img.shields.io/badge/license-MIT%2FApache--2.0-blue" alt="MIT OR Apache-2.0">
 </p>
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Not yet on crates.io. Until a crates.io release is available, depend on git:
 synaptic-mesh = { git = "https://github.com/Limen-Neural/synaptic-mesh" }
 ```
 
-After the `v0.1.0` tag exists you can pin it with `tag = "v0.1.0"`.
+Pin to a released tag with `tag = "v0.2.0"` (see [releases](https://github.com/Limen-Neural/synaptic-mesh/releases) for the latest).
 
 See [REVIEW.md](REVIEW.md#build-profiles) for which cargo build profile
 (`dev`, `test`, `release`, `bench`) to use and why.


### PR DESCRIPTION
## **User description**
Prepares the v0.2.0 release (milestone "v0.2.0 — Build & test tooling", closed).

## Summary

- Bumps `Cargo.toml`/`Cargo.lock` package version from `0.1.0` to `0.2.0`.
- Fills in the `[0.2.0]` CHANGELOG section covering the milestone's work since v0.1.0:
  - Cargo build profiles (`dev`/`test`/`release`/`bench`) — #40
  - CI now builds/compiles under all four profiles — #41
  - `cargo-deny` CI job for dependency/license auditing — #42
  - "Build profiles" documentation in `REVIEW.md` — #43
- Updates the `[Unreleased]` compare link to diff against `v0.2.0`.

Once merged, I'll tag `v0.2.0` on the merge commit and publish the GitHub release using this changelog entry.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --locked` (74 tests + 2 doctests pass)
- [x] `cargo metadata` confirms package version is `0.2.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P7afRMxHFJqnjdVqFkunyD

---
_Generated by [Claude Code](https://claude.ai/code/session_01P7afRMxHFJqnjdVqFkunyD)_


___

## **CodeAnt-AI Description**
Prepare the project for the v0.2.0 build and test tooling release

### What Changed
- Updates the package version and changelog for the v0.2.0 release
- Documents the v0.2.0 changes and updates the unreleased-change comparison link
- Records the build profiles, CI coverage, dependency checks, and build-profile documentation included in this release

### Impact
`✅ Clearer release history`
`✅ Accurate package version for v0.2.0`
`✅ Easier tracking of unreleased changes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepares the v0.2.0 release by bumping the package version from 0.1.0 to 0.2.0 and documenting the build & test tooling milestone in the CHANGELOG.

- CHANGELOG now documents the explicit `Cargo.toml` build profiles and the new "Build profiles" docs in `REVIEW.md` (issues #40, #43).
- CI now builds under all four profiles and adds a `cargo-deny` dependency/license audit job (issues #41, #42).
- README now shows the 0.2.0 version badge, pins installation to `v0.2.0`, and links to the releases page.
- The `[Unreleased]` compare link now diffs against `v0.2.0`.
- After merge, the `v0.2.0` tag and GitHub release will be created from this changelog entry.

<sup>Written for commit dc2f65c32c8fbcf45839251e70285ad52c96e9c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Limen-Neural/synaptic-mesh/pull/48?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

